### PR TITLE
fix: add github secrets to be env for process.env in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-stripe-lint
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-stripe-lint
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ jobs:
   lint_and_test:
     runs-on: ubuntu-latest
 
+    env:
+      NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes made

- [ ] New features
- [x] Bug fixes
- [x] Breaking changes
- [ ] Refactor

## Describe what you have done

- add github secrets to be env for process.env in ci

### New Features

-

### Fix

- fix stripe build error

### Others

-
