### PR TITLE
fix: only-credit-card

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -335,10 +335,7 @@ export default function CheckoutPage() {
               <SelectValue placeholder="Fill payment details" />
             </SelectTrigger>
             <SelectContent>
-              {/* Add your payment options here */}
               <SelectItem value="creditCard">Credit Card</SelectItem>
-              <SelectItem value="paypal">PayPal</SelectItem>
-              <SelectItem value="bankTransfer">Bank Transfer</SelectItem>
             </SelectContent>
           </Select>
 


### PR DESCRIPTION
## Changes made

- [ ] New features
- [X] Bug fixes
- [ ] Breaking changes
- [ ] Refactor

## Describe what you have done

- Remove payment option to have only Credit card

### New Features

-

### Fix

-

### Others

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed "PayPal" and "Bank Transfer" from the payment method options on the checkout page, leaving "Credit Card" as the sole available method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->