### PR TITLE
fix: filter self's posts in backend to make pagination amount equal

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,7 +1,9 @@
 import { Prisma } from "@prisma/client";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
 
+import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
 import { getUrl } from "../objects/s3";
@@ -91,10 +93,14 @@ export async function GET(req: NextRequest) {
       },
     };
 
+    const session = await getServerSession(authOptions);
     const posts = await prisma.post.findMany({
       where: {
         book: bookFilter,
         published: true,
+        sellerId: {
+          not: session?.user.id,
+        },
       },
       include: { book: true },
       skip,

--- a/src/app/search/components/PostList.tsx
+++ b/src/app/search/components/PostList.tsx
@@ -17,12 +17,9 @@ export const PostList = () => {
   const { posts, recommendedPosts, loading, error, setPostsFilters } = usePostContext();
 
   const filteredPosts = useMemo(() => {
-    let filteredPosts = posts.filter((post) => post.sellerId !== session?.user.id);
-    if (isBookmarkOnly) {
-      filteredPosts = filteredPosts.filter((post) => post.isBookmarked);
-    }
-    return filteredPosts;
-  }, [posts, session?.user.id, isBookmarkOnly]);
+    if (isBookmarkOnly) return posts.filter((post) => post.isBookmarked);
+    return posts;
+  }, [posts, isBookmarkOnly]);
 
   const filteredRecommendedPosts = useMemo(() => {
     const filteredRecommendedPosts = recommendedPosts.filter((post) => post.sellerId !== session?.user.id);


### PR DESCRIPTION
## Changes made

- [ ] New features
- [ ] Bug fixes
- [ ] Breaking changes
- [ ] Refactor

## Describe what you have done

-

### New Features

-

### Fix

-

### Others

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Posts created by the logged-in user are now excluded from general post listings.
	- In the search results, posts by the current user are no longer filtered out, ensuring all relevant posts are displayed when searching or viewing bookmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->