### PR TITLE
refactor: move revoke-seller to user management dashboard

### DIFF
--- a/src/app/admin/users/UserCard.tsx
+++ b/src/app/admin/users/UserCard.tsx
@@ -16,7 +16,9 @@ export default function UserCard({ user }: UserCardProps) {
           <span className="font-bold">
             {user.firstName} {user.lastName}
           </span>
-          {user.isSeller && <span className="mx-2 rounded-xl bg-pink-300 px-2 text-sm">ผู้ขาย</span>}
+          {user.isSeller && user.sellerProfile?.isApproved && (
+            <span className="mx-2 rounded-xl bg-pink-300 px-2 text-sm">ผู้ขาย</span>
+          )}
           {user.isAdmin && <span className="mx-2 rounded-xl bg-yellow-300 px-2 text-sm">แอดมิน</span>}
         </p>
         <p>{user.email}</p>

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -2,12 +2,12 @@ import { revalidatePath } from "next/cache";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { Button } from "@/components/ui/Button";
 import { verifyAdmin } from "@/lib/authorization";
 import { prisma } from "@/lib/prisma";
 
 import styles from "./styles.module.scss";
 import UserBan from "./UserBan";
-import { Button } from "@/components/ui/Button";
 
 export default async function ManageUserPage({ params }: { params: Promise<{ id: string }> }) {
   await verifyAdmin();
@@ -106,37 +106,35 @@ export default async function ManageUserPage({ params }: { params: Promise<{ id:
         <button type="submit">บันทึกข้อมูล</button>
       </form>
 
-      {user.isSeller &&
-        user.sellerProfile &&
-        user.sellerProfile.isApproved && (
-          <>
-            <h2 className="text-xl font-bold">จัดการโปรไฟล์ผู้ขาย</h2>
+      {user.isSeller && user.sellerProfile && user.sellerProfile.isApproved && (
+        <>
+          <h2 className="text-xl font-bold">จัดการโปรไฟล์ผู้ขาย</h2>
 
-            <div className="mt-4 flex w-full flex-col items-center gap-4 p-4">
-              <Button variant="link" size="lg" className="w-fit bg-pink-200">
-                <Link href={`/admin/verify-sellers/revoke/${user.id}`}>ระงับบัญชีผู้ขาย</Link>
-              </Button>
-            </div>
+          <div className="mt-4 flex w-full flex-col items-center gap-4 p-4">
+            <Button variant="link" size="lg" className="w-fit bg-pink-200">
+              <Link href={`/admin/verify-sellers/revoke/${user.id}`}>ระงับบัญชีผู้ขาย</Link>
+            </Button>
+          </div>
 
-            {reports.length > 0 && (
-              <>
-                <h2 className="text-xl font-bold">ประวัติการถูกรายงานโพสต์</h2>
+          {reports.length > 0 && (
+            <>
+              <h2 className="text-xl font-bold">ประวัติการถูกรายงานโพสต์</h2>
 
-                <div className="mt-2 flex w-full flex-col gap-2 px-4">
-                  {reports.map((report) => (
-                    <div key={report.id} className="rounded-lg border border-black p-2">
-                      <Link href={`/post/${report.postId}`} className="text-blue-500">
-                        ดูรายละเอียดโพสต์
-                      </Link>
-                      <p>เหตุผล: {report.reason}</p>
-                      <p>เวลาที่รายงาน: {report.createdAt.toLocaleString("th-TH")}</p>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-          </>,
-        )}
+              <div className="mt-2 flex w-full flex-col gap-2 px-4">
+                {reports.map((report) => (
+                  <div key={report.id} className="rounded-lg border border-black p-2">
+                    <Link href={`/post/${report.postId}`} className="text-blue-500">
+                      ดูรายละเอียดโพสต์
+                    </Link>
+                    <p>เหตุผล: {report.reason}</p>
+                    <p>เวลาที่รายงาน: {report.createdAt.toLocaleString("th-TH")}</p>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
 
       <UserBan user={user} />
     </main>

--- a/src/app/admin/users/query.ts
+++ b/src/app/admin/users/query.ts
@@ -10,6 +10,7 @@ export async function getUsers() {
           posts: true,
         },
       },
+      sellerProfile: true,
     },
     orderBy: {
       createdAt: "asc",

--- a/src/app/admin/verify-sellers/revoke/[id]/ProfileForm.tsx
+++ b/src/app/admin/verify-sellers/revoke/[id]/ProfileForm.tsx
@@ -114,7 +114,8 @@ export function ProfileForm({ initialData }: { initialData: UserProfile }) {
         description: "Seller profile updated successfully",
       });
       setIsEditing(false);
-      router.refresh();
+      alert("โปรไฟล์ผู้ขายถูกระงับเรียบร้อย");
+      router.push("/admin/users");
     } catch (error) {
       console.error("Error updating seller profile:", error);
       toast({


### PR DESCRIPTION
## Changes made

- [ ] New features
- [ ] Bug fixes
- [ ] Breaking changes
- [ ] Refactor

## Describe what you have done

-

### New Features

-

### Fix

-

### Others

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Seller profile management section is now only visible for approved seller profiles.
	- Users can now navigate directly to revoke a seller account via a dedicated button.

- **Improvements**
	- The "ผู้ขาย" (seller) badge is now displayed only for users with approved seller profiles.
	- User list now displays seller profile information alongside user records.

- **Bug Fixes**
	- After revoking a seller profile, users receive a confirmation alert and are redirected to the user management page.

- **Removed**
	- Editing of seller bank details and ID card information has been removed from the admin interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->